### PR TITLE
Fix compile scripts and run permuter

### DIFF
--- a/nonmatchings/func_800484C8/compile.bat
+++ b/nonmatchings/func_800484C8/compile.bat
@@ -1,1 +1,7 @@
- 
+@echo off
+set INPUT=%~f1
+set OUTPUT=%~f3
+set SCRIPT_DIR=%~dp0
+cd /d "%SCRIPT_DIR%..\.."
+
+"tools\ido-static-recomp\build\5.3\out\cc.exe" -c -Wab,-r4300_mul -non_shared -G 0 -Xcpluscomm -fullwarn -nostdinc -g0 -D_LANGUAGE_C -D_FINALROM -DF3D_OLD -DWIN32 -DSSSV -DNDEBUG -DTARGET_N64 -DCOMPILING_LIBULTRA -DVERSION_US -woff 649,838 -I . -I include/libc -I include/PR -I include -I assets -I src/os -O2 -mips2 -32 "%INPUT%" -o "%OUTPUT%"

--- a/nonmatchings/func_800484C8/compile.sh
+++ b/nonmatchings/func_800484C8/compile.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
+set -eu
+
 INPUT="$(realpath "$1")"
 OUTPUT="$(realpath "$3")"
-cd '/mnt/d/dev/AI/n64_projects/wave race n64 decomp/wr64'
-tools/ido-static-recomp/build/5.3/out/cc -c -Wab,-r4300_mul -non_shared -G 0 -Xcpluscomm -fullwarn -nostdinc -g0 -D_LANGUAGE_C -D_FINALROM -DF3D_OLD -DWIN32 -DSSSV -DNDEBUG -DTARGET_N64 -DCOMPILING_LIBULTRA -DVERSION_US -woff 649,838 -I . -I include/libc -I include/PR -I include -I assets -I src/os -O2 -mips2 -32 "$INPUT" -o "$OUTPUT"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+CC="tools/ido-static-recomp/build/5.3/out/cc"
+
+$CC -c -Wab,-r4300_mul -non_shared -G 0 -Xcpluscomm -fullwarn -nostdinc -g0 \
+    -D_LANGUAGE_C -D_FINALROM -DF3D_OLD -DWIN32 -DSSSV -DNDEBUG \
+    -DTARGET_N64 -DCOMPILING_LIBULTRA -DVERSION_US -woff 649,838 \
+    -I . -I include/libc -I include/PR -I include -I assets -I src/os \
+    -O2 -mips2 -32 "$INPUT" -o "$OUTPUT"

--- a/nonmatchings/func_8004A2B4/compile.bat
+++ b/nonmatchings/func_8004A2B4/compile.bat
@@ -1,5 +1,7 @@
 @echo off
 set INPUT=%~f1
 set OUTPUT=%~f3
-cd /d "D:\dev\AI\n64_projects\wave race n64 decomp\wr64"
-tools\ido-static-recomp\build\5.3\out\cc.exe -c -Wab,-r4300_mul -non_shared -G 0 -Xcpluscomm -fullwarn -nostdinc -g0 -D_LANGUAGE_C -D_FINALROM -DF3D_OLD -DWIN32 -DSSSV -DNDEBUG -DTARGET_N64 -DCOMPILING_LIBULTRA -DVERSION_US -woff 649,838 -I . -I include/libc -I include/PR -I include -I assets -I src/os -O2 -mips2 -32 "%INPUT%" -o "%OUTPUT%" 
+set SCRIPT_DIR=%~dp0
+cd /d "%SCRIPT_DIR%..\.."
+
+"tools\ido-static-recomp\build\5.3\out\cc.exe" -c -Wab,-r4300_mul -non_shared -G 0 -Xcpluscomm -fullwarn -nostdinc -g0 -D_LANGUAGE_C -D_FINALROM -DF3D_OLD -DWIN32 -DSSSV -DNDEBUG -DTARGET_N64 -DCOMPILING_LIBULTRA -DVERSION_US -woff 649,838 -I . -I include/libc -I include/PR -I include -I assets -I src/os -O2 -mips2 -32 "%INPUT%" -o "%OUTPUT%"

--- a/nonmatchings/func_8004A2B4/compile.sh
+++ b/nonmatchings/func_8004A2B4/compile.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
+set -eu
+
 INPUT="$(realpath "$1")"
 OUTPUT="$(realpath "$3")"
 
-# Cross-platform path detection
-if [[ "$PWD" == /mnt/d/* ]] || [[ "$PWD" == /d/* ]]; then
-    # WSL/Git Bash on Windows
-    cd '/mnt/d/dev/ai/n64_projects/wave race n64 decomp/wr64' 2>/dev/null || cd '/d/dev/ai/n64_projects/wave race n64 decomp/wr64'
-    CC_EXE="tools/ido-static-recomp/build/5.3/out/cc"
-else
-    # Native Linux/Unix
-    cd "$(dirname "$(dirname "$(realpath "$0")")")"
-    CC_EXE="tools/ido-static-recomp/build/5.3/out/cc"
-fi
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
 
-$CC_EXE -c -Wab,-r4300_mul -non_shared -G 0 -Xcpluscomm -fullwarn -nostdinc -g0 -D_LANGUAGE_C -D_FINALROM -DF3D_OLD -DWIN32 -DSSSV -DNDEBUG -DTARGET_N64 -DCOMPILING_LIBULTRA -DVERSION_US -woff 649,838 -I . -I include/libc -I include/PR -I include -I assets -I src/os -O2 -mips2 -32 "$INPUT" -o "$OUTPUT"
+CC="tools/ido-static-recomp/build/5.3/out/cc"
+
+$CC -c -Wab,-r4300_mul -non_shared -G 0 -Xcpluscomm -fullwarn -nostdinc -g0 \
+    -D_LANGUAGE_C -D_FINALROM -DF3D_OLD -DWIN32 -DSSSV -DNDEBUG \
+    -DTARGET_N64 -DCOMPILING_LIBULTRA -DVERSION_US -woff 649,838 \
+    -I . -I include/libc -I include/PR -I include -I assets -I src/os \
+    -O2 -mips2 -32 "$INPUT" -o "$OUTPUT"


### PR DESCRIPTION
## Summary
- rewrite compile scripts to detect repo root instead of hardcoding paths
- update Windows batch scripts similarly
- run the permuter on `func_800484C8` and capture base score

## Testing
- `python3 tools/decomp-permuter/permuter.py nonmatchings/func_800484C8 --debug`


------
https://chatgpt.com/codex/tasks/task_e_68583a03670083338f62aeaaa94c2c1a